### PR TITLE
change base URI to management API endpoint since some customers confuse i...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ var PROXY_OPTIONS = {
 };
 
 var REQUIRED_OPTIONS = [
-  { name: 'baseuri',      message: 'Base URI?', default: 'https://api.enterprise.apigee.com' },
+  { name: 'baseuri',      message: 'Management API Endpoint?', default: 'https://api.enterprise.apigee.com' },
   { name: 'organization', message: 'Organization?' },
   { name: 'username',     message: 'User Id?'  },
   { name: 'password',     message: 'Password?', type: 'password' },


### PR DESCRIPTION
...t with base uri of their api proxy on Apigee such as http://customer-test.apigee.net
